### PR TITLE
feat: add prisma schema and migrations

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -1,0 +1,37 @@
+name: API CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  api:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: api
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: api/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Prisma migrate deploy
+        if: ${{ hashFiles('api/prisma/migrations/**') != '' }}
+        run: npx prisma migrate deploy
+
+      - name: Validate Prisma schema
+        run: npx prisma validate
+
+      - name: Generate Prisma Client
+        run: npx prisma generate

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ pids/
 *.sqlite3
 *.db
 *.sql
+!api/prisma/migrations/**/*.sql
 dump.sql
 prisma/dev.db
 prisma/*.db

--- a/api/package.json
+++ b/api/package.json
@@ -3,7 +3,12 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "db:generate": "prisma generate",
+    "db:validate": "prisma validate",
+    "db:migrate": "prisma migrate dev",
+    "db:deploy": "prisma migrate deploy",
+    "db:seed": "ts-node --transpile-only --compiler-options '{\"module\":\"commonjs\",\"esModuleInterop\":true}' prisma/seed.ts"
   },
   "keywords": [],
   "author": "",

--- a/api/prisma/migrations/0001_init_domain/migration.sql
+++ b/api/prisma/migrations/0001_init_domain/migration.sql
@@ -1,0 +1,380 @@
+-- CreateSchema
+CREATE SCHEMA IF NOT EXISTS "public";
+
+-- CreateEnum
+CREATE TYPE "public"."Role" AS ENUM ('ADMIN', 'USER');
+
+-- CreateEnum
+CREATE TYPE "public"."EventStatus" AS ENUM ('DRAFT', 'ACTIVE', 'CLOSED', 'ARCHIVED');
+
+-- CreateEnum
+CREATE TYPE "public"."SubCompStatus" AS ENUM ('DRAFT', 'OPEN', 'CLOSED', 'CANCELED', 'SETTLED');
+
+-- CreateEnum
+CREATE TYPE "public"."BetStatus" AS ENUM ('PENDING', 'ACTIVE', 'EDITED', 'REFUNDED', 'SETTLED', 'CANCELED');
+
+-- CreateEnum
+CREATE TYPE "public"."SettlementStatus" AS ENUM ('PENDING', 'SENT', 'RECEIVED', 'CONFIRMED', 'DISPUTED', 'CANCELED');
+
+-- CreateEnum
+CREATE TYPE "public"."NotificationType" AS ENUM ('GENERIC', 'BET_CORRECTED', 'BETTING_CLOSED', 'RESULT_RECORDED', 'SETTLEMENT_CREATED', 'SETTLEMENT_SENT', 'SETTLEMENT_RECEIVED');
+
+-- CreateTable
+CREATE TABLE "public"."User" (
+    "id" SERIAL NOT NULL,
+    "username" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "email" TEXT,
+    "passwordHash" TEXT NOT NULL,
+    "role" "public"."Role" NOT NULL DEFAULT 'USER',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Event" (
+    "id" SERIAL NOT NULL,
+    "adminId" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "unitName" TEXT NOT NULL,
+    "joinCode" TEXT NOT NULL,
+    "houseCutBps" INTEGER NOT NULL DEFAULT 0,
+    "minBetUnits" INTEGER NOT NULL DEFAULT 1,
+    "maxBetUnits" INTEGER,
+    "status" "public"."EventStatus" NOT NULL DEFAULT 'DRAFT',
+    "timezone" TEXT NOT NULL,
+    "startsAt" TIMESTAMP(3),
+    "endsAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Event_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."EventMember" (
+    "id" SERIAL NOT NULL,
+    "eventId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "role" "public"."Role" NOT NULL DEFAULT 'USER',
+    "joinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "EventMember_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Participant" (
+    "id" SERIAL NOT NULL,
+    "eventId" INTEGER NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Participant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."SubCompetition" (
+    "id" SERIAL NOT NULL,
+    "eventId" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "status" "public"."SubCompStatus" NOT NULL DEFAULT 'DRAFT',
+    "bettingOpensAt" TIMESTAMP(3),
+    "bettingClosesAt" TIMESTAMP(3),
+    "finalizedAt" TIMESTAMP(3),
+    "minBetUnitsOverride" INTEGER,
+    "maxBetUnitsOverride" INTEGER,
+    "houseCutBpsOverride" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SubCompetition_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."SubCompEntry" (
+    "id" SERIAL NOT NULL,
+    "subCompetitionId" INTEGER NOT NULL,
+    "participantId" INTEGER,
+    "label" TEXT NOT NULL,
+    "orderIndex" INTEGER,
+    "isWithdrawn" BOOLEAN NOT NULL DEFAULT false,
+    "withdrawnAt" TIMESTAMP(3),
+    "finalOddsDecimal" DECIMAL(18,6),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SubCompEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Bet" (
+    "id" SERIAL NOT NULL,
+    "subCompetitionId" INTEGER NOT NULL,
+    "entryId" INTEGER,
+    "bettorId" INTEGER NOT NULL,
+    "amountUnits" INTEGER NOT NULL,
+    "status" "public"."BetStatus" NOT NULL DEFAULT 'PENDING',
+    "oddsSnapshot" DECIMAL(18,6),
+    "correctedReason" TEXT,
+    "correctedById" INTEGER,
+    "correctedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Bet_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Result" (
+    "id" SERIAL NOT NULL,
+    "subCompetitionId" INTEGER NOT NULL,
+    "winningEntryId" INTEGER,
+    "recordedById" INTEGER,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Result_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Payout" (
+    "id" SERIAL NOT NULL,
+    "subCompetitionId" INTEGER NOT NULL,
+    "betId" INTEGER NOT NULL,
+    "entryId" INTEGER,
+    "resultId" INTEGER,
+    "amount" DECIMAL(14,2) NOT NULL,
+    "netAmount" DECIMAL(14,2) NOT NULL,
+    "houseCutAmount" DECIMAL(14,2) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Payout_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Settlement" (
+    "id" SERIAL NOT NULL,
+    "eventId" INTEGER NOT NULL,
+    "payerId" INTEGER NOT NULL,
+    "payeeId" INTEGER NOT NULL,
+    "payoutId" INTEGER,
+    "amount" DECIMAL(14,2) NOT NULL,
+    "status" "public"."SettlementStatus" NOT NULL DEFAULT 'PENDING',
+    "dueAt" TIMESTAMP(3),
+    "sentAt" TIMESTAMP(3),
+    "receivedAt" TIMESTAMP(3),
+    "confirmedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Settlement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Notification" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "eventId" INTEGER,
+    "type" "public"."NotificationType" NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "metadata" JSONB,
+    "readAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Notification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."AuditLog" (
+    "id" SERIAL NOT NULL,
+    "eventId" INTEGER,
+    "userId" INTEGER,
+    "subCompetitionId" INTEGER,
+    "betId" INTEGER,
+    "action" TEXT NOT NULL,
+    "details" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_username_key" ON "public"."User"("username");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "public"."User"("email");
+
+-- CreateIndex
+CREATE INDEX "User_username_idx" ON "public"."User"("username");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Event_joinCode_key" ON "public"."Event"("joinCode");
+
+-- CreateIndex
+CREATE INDEX "Event_adminId_idx" ON "public"."Event"("adminId");
+
+-- CreateIndex
+CREATE INDEX "Event_status_idx" ON "public"."Event"("status");
+
+-- CreateIndex
+CREATE INDEX "EventMember_userId_idx" ON "public"."EventMember"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EventMember_eventId_userId_key" ON "public"."EventMember"("eventId", "userId");
+
+-- CreateIndex
+CREATE INDEX "Participant_eventId_isActive_idx" ON "public"."Participant"("eventId", "isActive");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Participant_eventId_displayName_key" ON "public"."Participant"("eventId", "displayName");
+
+-- CreateIndex
+CREATE INDEX "SubCompetition_eventId_idx" ON "public"."SubCompetition"("eventId");
+
+-- CreateIndex
+CREATE INDEX "SubCompetition_status_idx" ON "public"."SubCompetition"("status");
+
+-- CreateIndex
+CREATE INDEX "SubCompEntry_participantId_idx" ON "public"."SubCompEntry"("participantId");
+
+-- CreateIndex
+CREATE INDEX "SubCompEntry_subCompetitionId_isWithdrawn_idx" ON "public"."SubCompEntry"("subCompetitionId", "isWithdrawn");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SubCompEntry_subCompetitionId_label_key" ON "public"."SubCompEntry"("subCompetitionId", "label");
+
+-- CreateIndex
+CREATE INDEX "Bet_bettorId_idx" ON "public"."Bet"("bettorId");
+
+-- CreateIndex
+CREATE INDEX "Bet_subCompetitionId_status_idx" ON "public"."Bet"("subCompetitionId", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Result_subCompetitionId_key" ON "public"."Result"("subCompetitionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Result_winningEntryId_key" ON "public"."Result"("winningEntryId");
+
+-- CreateIndex
+CREATE INDEX "Payout_subCompetitionId_idx" ON "public"."Payout"("subCompetitionId");
+
+-- CreateIndex
+CREATE INDEX "Payout_resultId_idx" ON "public"."Payout"("resultId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Payout_betId_key" ON "public"."Payout"("betId");
+
+-- CreateIndex
+CREATE INDEX "Settlement_payerId_idx" ON "public"."Settlement"("payerId");
+
+-- CreateIndex
+CREATE INDEX "Settlement_payeeId_idx" ON "public"."Settlement"("payeeId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Settlement_eventId_payerId_payeeId_key" ON "public"."Settlement"("eventId", "payerId", "payeeId");
+
+-- CreateIndex
+CREATE INDEX "Notification_userId_readAt_idx" ON "public"."Notification"("userId", "readAt");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_eventId_idx" ON "public"."AuditLog"("eventId");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_userId_idx" ON "public"."AuditLog"("userId");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_subCompetitionId_idx" ON "public"."AuditLog"("subCompetitionId");
+
+-- AddForeignKey
+ALTER TABLE "public"."Event" ADD CONSTRAINT "Event_adminId_fkey" FOREIGN KEY ("adminId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."EventMember" ADD CONSTRAINT "EventMember_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "public"."Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."EventMember" ADD CONSTRAINT "EventMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Participant" ADD CONSTRAINT "Participant_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "public"."Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."SubCompetition" ADD CONSTRAINT "SubCompetition_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "public"."Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."SubCompEntry" ADD CONSTRAINT "SubCompEntry_subCompetitionId_fkey" FOREIGN KEY ("subCompetitionId") REFERENCES "public"."SubCompetition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."SubCompEntry" ADD CONSTRAINT "SubCompEntry_participantId_fkey" FOREIGN KEY ("participantId") REFERENCES "public"."Participant"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Bet" ADD CONSTRAINT "Bet_subCompetitionId_fkey" FOREIGN KEY ("subCompetitionId") REFERENCES "public"."SubCompetition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Bet" ADD CONSTRAINT "Bet_entryId_fkey" FOREIGN KEY ("entryId") REFERENCES "public"."SubCompEntry"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Bet" ADD CONSTRAINT "Bet_bettorId_fkey" FOREIGN KEY ("bettorId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Bet" ADD CONSTRAINT "Bet_correctedById_fkey" FOREIGN KEY ("correctedById") REFERENCES "public"."User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Result" ADD CONSTRAINT "Result_subCompetitionId_fkey" FOREIGN KEY ("subCompetitionId") REFERENCES "public"."SubCompetition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Result" ADD CONSTRAINT "Result_winningEntryId_fkey" FOREIGN KEY ("winningEntryId") REFERENCES "public"."SubCompEntry"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Result" ADD CONSTRAINT "Result_recordedById_fkey" FOREIGN KEY ("recordedById") REFERENCES "public"."User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Payout" ADD CONSTRAINT "Payout_subCompetitionId_fkey" FOREIGN KEY ("subCompetitionId") REFERENCES "public"."SubCompetition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Payout" ADD CONSTRAINT "Payout_betId_fkey" FOREIGN KEY ("betId") REFERENCES "public"."Bet"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Payout" ADD CONSTRAINT "Payout_entryId_fkey" FOREIGN KEY ("entryId") REFERENCES "public"."SubCompEntry"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Payout" ADD CONSTRAINT "Payout_resultId_fkey" FOREIGN KEY ("resultId") REFERENCES "public"."Result"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Settlement" ADD CONSTRAINT "Settlement_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "public"."Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Settlement" ADD CONSTRAINT "Settlement_payerId_fkey" FOREIGN KEY ("payerId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Settlement" ADD CONSTRAINT "Settlement_payeeId_fkey" FOREIGN KEY ("payeeId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Settlement" ADD CONSTRAINT "Settlement_payoutId_fkey" FOREIGN KEY ("payoutId") REFERENCES "public"."Payout"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Notification" ADD CONSTRAINT "Notification_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Notification" ADD CONSTRAINT "Notification_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "public"."Event"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AuditLog" ADD CONSTRAINT "AuditLog_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "public"."Event"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AuditLog" ADD CONSTRAINT "AuditLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AuditLog" ADD CONSTRAINT "AuditLog_subCompetitionId_fkey" FOREIGN KEY ("subCompetitionId") REFERENCES "public"."SubCompetition"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AuditLog" ADD CONSTRAINT "AuditLog_betId_fkey" FOREIGN KEY ("betId") REFERENCES "public"."Bet"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/api/prisma/migrations/migration_lock.toml
+++ b/api/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1,0 +1,309 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum Role {
+  ADMIN
+  USER
+}
+
+enum EventStatus {
+  DRAFT
+  ACTIVE
+  CLOSED
+  ARCHIVED
+}
+
+enum SubCompStatus {
+  DRAFT
+  OPEN
+  CLOSED
+  CANCELED
+  SETTLED
+}
+
+enum BetStatus {
+  PENDING
+  ACTIVE
+  EDITED
+  REFUNDED
+  SETTLED
+  CANCELED
+}
+
+enum SettlementStatus {
+  PENDING
+  SENT
+  RECEIVED
+  CONFIRMED
+  DISPUTED
+  CANCELED
+}
+
+enum NotificationType {
+  GENERIC
+  BET_CORRECTED
+  BETTING_CLOSED
+  RESULT_RECORDED
+  SETTLEMENT_CREATED
+  SETTLEMENT_SENT
+  SETTLEMENT_RECEIVED
+}
+
+model User {
+  id             Int            @id @default(autoincrement())
+  username       String         @unique
+  displayName    String
+  email          String?        @unique
+  passwordHash   String
+  role           Role           @default(USER)
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime       @updatedAt
+  events         Event[]        @relation("EventAdmin")
+  memberships    EventMember[]
+  bets           Bet[]
+  notifications  Notification[]
+  auditLogs      AuditLog[]
+  settlementsOut Settlement[]   @relation("SettlementPayer")
+  settlementsIn  Settlement[]   @relation("SettlementPayee")
+  results        Result[]       @relation("ResultRecorder")
+  correctedBets  Bet[]          @relation("BetCorrector")
+
+  @@index([username])
+}
+
+model Event {
+  id              Int              @id @default(autoincrement())
+  adminId         Int
+  admin           User             @relation("EventAdmin", fields: [adminId], references: [id], onDelete: Cascade)
+  title           String
+  description     String?
+  unitName        String
+  joinCode        String           @unique
+  houseCutBps     Int              @default(0)
+  minBetUnits     Int              @default(1)
+  maxBetUnits     Int?
+  status          EventStatus      @default(DRAFT)
+  timezone        String
+  startsAt        DateTime?
+  endsAt          DateTime?
+  createdAt       DateTime         @default(now())
+  updatedAt       DateTime         @updatedAt
+  members         EventMember[]
+  participants    Participant[]
+  subCompetitions SubCompetition[]
+  notifications   Notification[]
+  auditLogs       AuditLog[]
+  settlements     Settlement[]
+
+  @@index([adminId])
+  @@index([status])
+}
+
+model EventMember {
+  id       Int      @id @default(autoincrement())
+  eventId  Int
+  userId   Int
+  role     Role     @default(USER)
+  joinedAt DateTime @default(now())
+
+  event Event @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([eventId, userId])
+  @@index([userId])
+}
+
+model Participant {
+  id          Int      @id @default(autoincrement())
+  eventId     Int
+  displayName String
+  isActive    Boolean  @default(true)
+  notes       String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  event   Event          @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  entries SubCompEntry[]
+
+  @@unique([eventId, displayName])
+  @@index([eventId, isActive])
+}
+
+model SubCompetition {
+  id                  Int           @id @default(autoincrement())
+  eventId             Int
+  title               String
+  description         String?
+  status              SubCompStatus @default(DRAFT)
+  bettingOpensAt      DateTime?
+  bettingClosesAt     DateTime?
+  finalizedAt         DateTime?
+  minBetUnitsOverride Int?
+  maxBetUnitsOverride Int?
+  houseCutBpsOverride Int?
+  createdAt           DateTime      @default(now())
+  updatedAt           DateTime      @updatedAt
+
+  event     Event          @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  entries   SubCompEntry[]
+  bets      Bet[]
+  result    Result?
+  payouts   Payout[]
+  auditLogs AuditLog[]
+
+  @@index([eventId])
+  @@index([status])
+}
+
+model SubCompEntry {
+  id               Int       @id @default(autoincrement())
+  subCompetitionId Int
+  participantId    Int?
+  label            String
+  orderIndex       Int?
+  isWithdrawn      Boolean   @default(false)
+  withdrawnAt      DateTime?
+  finalOddsDecimal Decimal?  @db.Decimal(18, 6)
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+
+  subCompetition SubCompetition @relation(fields: [subCompetitionId], references: [id], onDelete: Cascade)
+  participant    Participant?   @relation(fields: [participantId], references: [id], onDelete: SetNull)
+  bets           Bet[]
+  payouts        Payout[]
+  winningResult  Result?        @relation("WinningEntry")
+
+  @@unique([subCompetitionId, label])
+  @@index([participantId])
+  @@index([subCompetitionId, isWithdrawn])
+}
+
+model Bet {
+  id               Int       @id @default(autoincrement())
+  subCompetitionId Int
+  entryId          Int?
+  bettorId         Int
+  amountUnits      Int
+  status           BetStatus @default(PENDING)
+  oddsSnapshot     Decimal?  @db.Decimal(18, 6)
+  correctedReason  String?
+  correctedById    Int?
+  correctedAt      DateTime?
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+
+  subCompetition SubCompetition @relation(fields: [subCompetitionId], references: [id], onDelete: Cascade)
+  entry          SubCompEntry?  @relation(fields: [entryId], references: [id], onDelete: SetNull)
+  bettor         User           @relation(fields: [bettorId], references: [id], onDelete: Cascade)
+  correctedBy    User?          @relation("BetCorrector", fields: [correctedById], references: [id], onDelete: SetNull)
+  payout         Payout?
+  auditLogs      AuditLog[]
+
+  @@index([bettorId])
+  @@index([subCompetitionId, status])
+}
+
+model Result {
+  id               Int      @id @default(autoincrement())
+  subCompetitionId Int      @unique
+  winningEntryId   Int?     @unique
+  recordedById     Int?
+  notes            String?
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  subCompetition SubCompetition @relation(fields: [subCompetitionId], references: [id], onDelete: Cascade)
+  winningEntry   SubCompEntry?  @relation("WinningEntry", fields: [winningEntryId], references: [id], onDelete: SetNull)
+  recordedBy     User?          @relation("ResultRecorder", fields: [recordedById], references: [id], onDelete: SetNull)
+  payouts        Payout[]
+}
+
+model Payout {
+  id               Int      @id @default(autoincrement())
+  subCompetitionId Int
+  betId            Int
+  entryId          Int?
+  resultId         Int?
+  amount           Decimal  @db.Decimal(14, 2)
+  netAmount        Decimal  @db.Decimal(14, 2)
+  houseCutAmount   Decimal  @db.Decimal(14, 2)
+  createdAt        DateTime @default(now())
+
+  subCompetition SubCompetition @relation(fields: [subCompetitionId], references: [id], onDelete: Cascade)
+  bet            Bet            @relation(fields: [betId], references: [id], onDelete: Cascade)
+  entry          SubCompEntry?  @relation(fields: [entryId], references: [id], onDelete: SetNull)
+  result         Result?        @relation(fields: [resultId], references: [id], onDelete: SetNull)
+  settlement     Settlement?    @relation("PayoutSettlement")
+
+  @@unique([betId])
+  @@index([subCompetitionId])
+  @@index([resultId])
+}
+
+model Settlement {
+  id          Int              @id @default(autoincrement())
+  eventId     Int
+  payerId     Int
+  payeeId     Int
+  payoutId    Int?             @unique
+  amount      Decimal          @db.Decimal(14, 2)
+  status      SettlementStatus @default(PENDING)
+  dueAt       DateTime?
+  sentAt      DateTime?
+  receivedAt  DateTime?
+  confirmedAt DateTime?
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+
+  event  Event   @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  payer  User    @relation("SettlementPayer", fields: [payerId], references: [id], onDelete: Cascade)
+  payee  User    @relation("SettlementPayee", fields: [payeeId], references: [id], onDelete: Cascade)
+  payout Payout? @relation("PayoutSettlement", fields: [payoutId], references: [id], onDelete: SetNull)
+
+  @@unique([eventId, payerId, payeeId])
+  @@index([payerId])
+  @@index([payeeId])
+}
+
+model Notification {
+  id        Int              @id @default(autoincrement())
+  userId    Int
+  eventId   Int?
+  type      NotificationType
+  title     String
+  body      String
+  metadata  Json?
+  readAt    DateTime?
+  createdAt DateTime         @default(now())
+
+  user  User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  event Event? @relation(fields: [eventId], references: [id], onDelete: SetNull)
+
+  @@index([userId, readAt])
+}
+
+model AuditLog {
+  id               Int      @id @default(autoincrement())
+  eventId          Int?
+  userId           Int?
+  subCompetitionId Int?
+  betId            Int?
+  action           String
+  details          Json?
+  createdAt        DateTime @default(now())
+
+  event          Event?          @relation(fields: [eventId], references: [id], onDelete: SetNull)
+  user           User?           @relation(fields: [userId], references: [id], onDelete: SetNull)
+  subCompetition SubCompetition? @relation(fields: [subCompetitionId], references: [id], onDelete: SetNull)
+  bet            Bet?            @relation(fields: [betId], references: [id], onDelete: SetNull)
+
+  @@index([eventId])
+  @@index([userId])
+  @@index([subCompetitionId])
+}

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -1,0 +1,126 @@
+import { PrismaClient, Role, EventStatus, SubCompStatus } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const passwordHash = await bcrypt.hash('changeme', 10);
+
+  const admin = await prisma.user.upsert({
+    where: { username: 'admin' },
+    update: {},
+    create: {
+      username: 'admin',
+      displayName: 'Admin User',
+      passwordHash,
+      role: Role.ADMIN,
+      email: 'admin@example.com',
+    },
+  });
+
+  const event = await prisma.event.upsert({
+    where: { joinCode: 'JOIN-CODE-1' },
+    update: {},
+    create: {
+      adminId: admin.id,
+      title: 'Autumn Invitational',
+      description: 'Seeded friends betting event',
+      unitName: 'Godisbilar',
+      joinCode: 'JOIN-CODE-1',
+      houseCutBps: 0,
+      minBetUnits: 1,
+      maxBetUnits: 25,
+      status: EventStatus.ACTIVE,
+      timezone: 'Europe/Stockholm',
+      members: {
+        create: {
+          userId: admin.id,
+          role: Role.ADMIN,
+        },
+      },
+    },
+  });
+
+  const participantNames = ['Alice', 'Bob', 'Charlie', 'Diana'];
+  const participants = [] as { id: number; displayName: string }[];
+
+  for (const name of participantNames) {
+    const participant = await prisma.participant.upsert({
+      where: {
+        eventId_displayName: {
+          eventId: event.id,
+          displayName: name,
+        },
+      },
+      update: {},
+      create: {
+        eventId: event.id,
+        displayName: name,
+        notes: 'Seed participant',
+      },
+    });
+    participants.push({ id: participant.id, displayName: participant.displayName });
+  }
+
+  const now = new Date();
+  const close = new Date(now.getTime() + 60 * 60 * 1000);
+
+  const existingRoundOne = await prisma.subCompetition.findFirst({
+    where: { eventId: event.id, title: 'Round 1 Winner' },
+  });
+
+  if (!existingRoundOne) {
+    await prisma.subCompetition.create({
+      data: {
+        eventId: event.id,
+        title: 'Round 1 Winner',
+        description: 'Who wins the opening round?',
+        status: SubCompStatus.OPEN,
+        bettingOpensAt: now,
+        bettingClosesAt: close,
+        entries: {
+          create: participants.slice(0, 3).map((participant, index) => ({
+            participantId: participant.id,
+            label: participant.displayName,
+            orderIndex: index,
+          })),
+        },
+      },
+    });
+  }
+
+  const existingClosest = await prisma.subCompetition.findFirst({
+    where: { eventId: event.id, title: 'Closest to Pin' },
+  });
+
+  if (!existingClosest) {
+    await prisma.subCompetition.create({
+      data: {
+        eventId: event.id,
+        title: 'Closest to Pin',
+        description: 'Best shot on hole 7',
+        status: SubCompStatus.DRAFT,
+        bettingOpensAt: now,
+        bettingClosesAt: close,
+        entries: {
+          create: participants.map((participant, index) => ({
+            participantId: participant.id,
+            label: `${participant.displayName} Shot`,
+            orderIndex: index,
+          })),
+        },
+      },
+    });
+  }
+
+  console.log('Seed data created successfully.');
+}
+
+main()
+  .catch((error) => {
+    console.error('Seed failed:', error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- add a Prisma schema that covers the Wineify domain models and enums
- check in the initial Prisma migration and optional seed script
- update npm scripts and CI to run Prisma tooling with migrate deploy when migrations exist

## Testing
- npx prisma validate
- npx prisma generate

------
https://chatgpt.com/codex/tasks/task_e_68cdaa7ef804832690d4cd47214f35da